### PR TITLE
KAS-1422 rename relation

### DIFF
--- a/queries/agenda.js
+++ b/queries/agenda.js
@@ -18,7 +18,7 @@ const fetchFilesFromAgenda = async (agendaId) => {
           mu:uuid ${sparqlEscapeString(agendaId)} ;
           dct:hasPart ?agendaitem .
       ?agendaitem a besluit:Agendapunt ;
-          ext:bevatAgendapuntDocumentversie ?document .
+          besluitvorming:geagendeerdStuk ?document .
       ?document a dossier:Stuk ;
           dct:title ?documentName ;
           ext:file ?file .


### PR DESCRIPTION
# KAS-1422: uiteentrekken van agendaitem / subcase modellen
In deze model refactor heb ik gekeken welke data we nog onnodige dupliceren op beide modellen en ook vergelijken hoe het in het nieuwe oslo model zit.
Hieruit is gebleken dat de duplicatie al fel verminderd is t.o.v. vroeger, toen het ticket aangemaakt geweest is.
Ik heb voornamelijk wat prefixen correct gezet, en verwijdert wat weg mocht.

## ✏️ What has changed
- ext:bevatAgendapuntDocumentversie => besluitvorming:geagendeerdStuk