### PR TITLE
KAS-3658: Source file as main file

### DIFF
--- a/queries/agenda.js
+++ b/queries/agenda.js
@@ -4,13 +4,13 @@ import { parseSparqlResults } from './util';
 const fetchFilesFromAgenda = async (agendaId) => {
   const queryString = `
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
   PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
   PREFIX dct: <http://purl.org/dc/terms/>
   PREFIX dbpedia: <http://dbpedia.org/ontology/>
   PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
   PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+  PREFIX prov: <http://www.w3.org/ns/prov#>
 
   SELECT DISTINCT (?file AS ?uri) ?name ?extension ?document ?documentName
   WHERE {
@@ -20,8 +20,8 @@ const fetchFilesFromAgenda = async (agendaId) => {
       ?agendaitem a besluit:Agendapunt ;
           besluitvorming:geagendeerdStuk ?document .
       ?document a dossier:Stuk ;
-          dct:title ?documentName ;
-          ext:file ?file .
+          dct:title ?documentName .
+      ?document prov:value / ^prov:hadPrimarySource? ?file .
       ?file a nfo:FileDataObject ;
           nfo:fileName ?name ;
           dbpedia:fileExtension ?extension .

--- a/queries/document.js
+++ b/queries/document.js
@@ -9,7 +9,6 @@ async function renameFileFromDocument (doc, file, newFileName) {
    */
   const q = `
   PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
-  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
   PREFIX prov: <http://www.w3.org/ns/prov#>
 

--- a/queries/document.js
+++ b/queries/document.js
@@ -11,6 +11,7 @@ async function renameFileFromDocument (doc, file, newFileName) {
   PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
   PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+  PREFIX prov: <http://www.w3.org/ns/prov#>
 
   DELETE {
       GRAPH ?g {
@@ -25,7 +26,7 @@ async function renameFileFromDocument (doc, file, newFileName) {
   WHERE {
       GRAPH ?g {
           ${sparqlEscapeUri(doc)} a dossier:Stuk ;
-              ext:file ${sparqlEscapeUri(file)} .
+              prov:value ${sparqlEscapeUri(file)} .
           ${sparqlEscapeUri(file)} a nfo:FileDataObject ;
               nfo:fileName ?fileName .
           FILTER (?fileName != ${sparqlEscapeString(newFileName)})


### PR DESCRIPTION
When creating file bundling jobs (for users who clicked on the "Download alle documenten" button of an agenda), bundle both source and derived files (if the latter exist).