### PR TITLE
KAS-3883: Bundle agenda documents per mandatees

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See [file-bundling-service](https://github.com/kanselarij-vlaanderen/file-bundli
 
 ## REST API
 #### POST /agendas/:agenda_id/agendaitems/documents/files/archive
-Request the creation of an archive of all files related to agenda `:agenda_id`.
+Request the creation of an archive of all files related to agenda `:agenda_id`. An optional query parameter is allowed, `mandateeIds`, which is a comma-separated string containing the ids of mandatees whose documents we want to fetch. When `mandateeIds` is provided all document linked to an agendaitem which are linked to the listed mandatees will be bundled, as well as all documents linked to an agendaitem with no linked mandatees. If `mandateeIds` is not provided all documents of the agenda will be bundled.
 
 ##### Response
 ###### 201 Created

--- a/app.js
+++ b/app.js
@@ -1,13 +1,20 @@
 import { app, errorHandler } from 'mu';
 
-import { fetchFilesFromAgenda } from './queries/agenda';
+import { fetchFilesFromAgenda, fetchFilesFromAgendaByMandatees } from './queries/agenda';
 import { createJob, insertAndattachCollectionToJob, updateJobStatus, findJobUsingCollection } from './queries/job';
 import { findCollectionByMembers } from './queries/collection';
 import { overwriteFilenames } from './lib/overwrite-filename';
 import { JSONAPI_JOB_TYPE } from './config';
 
 app.post('/agendas/:agenda_id/agendaitems/documents/files/archive', async (req, res) => {
-  const files = await fetchFilesFromAgenda(req.params.agenda_id);
+  const mandateeIdsString = req.query.mandateeIds;
+  let files;
+  if (mandateeIdsString) {
+    const mandateeIds = mandateeIdsString.split(',');
+    files = await fetchFilesFromAgendaByMandatees(req.params.agenda_id, mandateeIds);
+  } else {
+    files = await fetchFilesFromAgenda(req.params.agenda_id);
+  }
   const collection = await findCollectionByMembers(files.map(m => m.uri));
   let job;
   if (collection) {

--- a/queries/agenda.js
+++ b/queries/agenda.js
@@ -30,6 +30,44 @@ const fetchFilesFromAgenda = async (agendaId) => {
   return parseSparqlResults(data);
 };
 
+const fetchFilesFromAgendaByMandatees = async (agendaId, mandateeIds) => {
+  const queryString = `
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+  PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+  PREFIX dct: <http://purl.org/dc/terms/>
+  PREFIX dbpedia: <http://dbpedia.org/ontology/>
+  PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+  PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+  PREFIX prov: <http://www.w3.org/ns/prov#>
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+  SELECT DISTINCT (?file AS ?uri) ?name ?extension ?document ?documentName
+  WHERE {
+      ?agenda a besluitvorming:Agenda ;
+          mu:uuid ${sparqlEscapeString(agendaId)} ;
+          dct:hasPart ?agendaitem .
+      ?agendaitem a besluit:Agendapunt ;
+          besluitvorming:geagendeerdStuk ?document .
+      {
+        ?agendaitem ext:heeftBevoegdeVoorAgendapunt ?mandatee .
+        ?mandatee mu:uuid ?mandateeId .
+        FILTER (?mandateeId IN (${mandateeIds.map((id) => sparqlEscapeString(id)).join(', ')}))
+      } UNION {
+        FILTER NOT EXISTS { ?agendaitem ext:heeftBevoegdeVoorAgendapunt ?mandatee }
+      }
+      ?document a dossier:Stuk ;
+          dct:title ?documentName .
+      ?document prov:value / ^prov:hadPrimarySource? ?file .
+      ?file a nfo:FileDataObject ;
+          nfo:fileName ?name ;
+          dbpedia:fileExtension ?extension .
+  }`;
+  const data = await query(queryString);
+  return parseSparqlResults(data);
+}
+
 export {
-  fetchFilesFromAgenda
+  fetchFilesFromAgenda,
+  fetchFilesFromAgendaByMandatees,
 };


### PR DESCRIPTION
Optionally allow bundling of agenda documents per mandatees. Uses query param `mandateeIds` to determine which mandatees' files a user wants to bundle.