### PR TITLE
fix: rename derived files too

### DIFF
--- a/queries/document.js
+++ b/queries/document.js
@@ -28,7 +28,7 @@ async function renameFileFromDocument (doc, file, newFileName) {
               prov:value ${sparqlEscapeUri(file)} . }
           UNION
           { ${sparqlEscapeUri(doc)} a dossier:Stuk ;
-              prov:value / ^prov:hadPrimarySource? ${sparqlEscapeUri(file)} . }
+              prov:value / ^prov:hadPrimarySource ${sparqlEscapeUri(file)} . }
           ${sparqlEscapeUri(file)} a nfo:FileDataObject ;
               nfo:fileName ?fileName .
           FILTER (?fileName != ${sparqlEscapeString(newFileName)})

--- a/queries/document.js
+++ b/queries/document.js
@@ -25,7 +25,7 @@ async function renameFileFromDocument (doc, file, newFileName) {
   WHERE {
       GRAPH ?g {
           ${sparqlEscapeUri(doc)} a dossier:Stuk ;
-              prov:value ${sparqlEscapeUri(file)} .
+              prov:value / ^prov:hadPrimarySource? ${sparqlEscapeUri(file)} .
           ${sparqlEscapeUri(file)} a nfo:FileDataObject ;
               nfo:fileName ?fileName .
           FILTER (?fileName != ${sparqlEscapeString(newFileName)})

--- a/queries/document.js
+++ b/queries/document.js
@@ -24,8 +24,11 @@ async function renameFileFromDocument (doc, file, newFileName) {
   }
   WHERE {
       GRAPH ?g {
-          ${sparqlEscapeUri(doc)} a dossier:Stuk ;
-              prov:value / ^prov:hadPrimarySource? ${sparqlEscapeUri(file)} .
+          { ${sparqlEscapeUri(doc)} a dossier:Stuk ;
+              prov:value ${sparqlEscapeUri(file)} . }
+          UNION
+          { ${sparqlEscapeUri(doc)} a dossier:Stuk ;
+              prov:value / ^prov:hadPrimarySource? ${sparqlEscapeUri(file)} . }
           ${sparqlEscapeUri(file)} a nfo:FileDataObject ;
               nfo:fileName ?fileName .
           FILTER (?fileName != ${sparqlEscapeString(newFileName)})


### PR DESCRIPTION
When bundling files for an agenda we rename the (virtual) file to match the piece's name. Now we also do so for the derived file.