### PR TITLE
KAS-4990 add filtering on released decisions and decision result

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 import { app, errorHandler } from 'mu';
 
-import { fetchFilesFromAgenda, fetchFilesFromAgendaByMandatees, fetchDecisionsByMandatees, fetchDecisionsFromAgenda} from './queries/agenda';
+import { fetchFilesFromAgenda, fetchFilesFromAgendaByMandatees, fetchDecisionsByMandatees, fetchDecisionsFromAgenda, fetchAreDecisionsReleased} from './queries/agenda';
 import { createJob, insertAndattachCollectionToJob, updateJobStatus, findJobUsingCollection } from './queries/job';
 import { findCollectionByMembers } from './queries/collection';
 import { fetchCurrentUser, filterByConfidentiality } from './queries/user';
@@ -15,18 +15,19 @@ app.post('/agendas/:agenda_id/agendaitems/documents/files/archive', async (req, 
   let decisions = req.query.decisions === 'true';
   let files;
   const currentUser = await fetchCurrentUser(req.headers['mu-session-id']);
+  const areDecisionsReleased = await fetchAreDecisionsReleased(req.params.agenda_id);
   if (mandateeIdsString) {
     const mandateeIds = mandateeIdsString.split(',');
     if (decisions){
       files = await fetchDecisionsByMandatees(req.params.agenda_id, mandateeIds, currentUser, extensions)
     } else {
-      files = await fetchFilesFromAgendaByMandatees(req.params.agenda_id, mandateeIds, currentUser, extensions);
+      files = await fetchFilesFromAgendaByMandatees(req.params.agenda_id, mandateeIds, currentUser, extensions, areDecisionsReleased);
     }
   } else {
     if (decisions){
       files = await fetchDecisionsFromAgenda(req.params.agenda_id, currentUser, extensions);
     } else {
-      files = await fetchFilesFromAgenda(req.params.agenda_id, currentUser, extensions);
+      files = await fetchFilesFromAgenda(req.params.agenda_id, currentUser, extensions, areDecisionsReleased);
     }
   }
   files = await filterByConfidentiality(files, currentUser, decisions);

--- a/config.js
+++ b/config.js
@@ -4,10 +4,16 @@ const JSONAPI_JOB_TYPE = 'file-bundling-jobs';
 const LIMITED_ACCESS_ROLES = ['http://themis.vlaanderen.be/id/gebruikersrol/6bcebe59-0cb5-4c5e-ab40-ca98b65887a4'];
 const ACCESS_LEVEL_CONFIDENTIAL = "http://themis.vlaanderen.be/id/concept/toegangsniveau/9692ba4f-f59b-422b-9402-fcbd30a46d17";
 
+const DECISION_RESULT_CODES_LIST = [
+  "http://themis.vlaanderen.be/id/concept/beslissing-resultaatcodes/a29b3ffd-0839-45cb-b8f4-e1760f7aacaa",
+  "http://themis.vlaanderen.be/id/concept/beslissing-resultaatcodes/453a36e8-6fbd-45d3-b800-ec96e59f273b"
+];
+
 module.exports = {
   RESOURCE_BASE,
   RDF_JOB_TYPE,
   JSONAPI_JOB_TYPE,
   LIMITED_ACCESS_ROLES,
   ACCESS_LEVEL_CONFIDENTIAL,
+  DECISION_RESULT_CODES_LIST
 };

--- a/queries/agenda.js
+++ b/queries/agenda.js
@@ -1,7 +1,8 @@
-import { sparqlEscapeString, query } from 'mu';
+import { sparqlEscapeString, sparqlEscapeUri, query } from 'mu';
 import { parseSparqlResults } from './util';
+import { DECISION_RESULT_CODES_LIST } from '../config';
 
-const fetchFilesFromAgenda = async (agendaId, currentUser, extensions) => {
+const fetchFilesFromAgenda = async (agendaId, currentUser, extensions, areDecisionsReleased) => {
   let queryString = `
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
@@ -26,6 +27,16 @@ const fetchFilesFromAgenda = async (agendaId, currentUser, extensions) => {
       ?document a dossier:Stuk ;
           dct:title ?documentName .
       ?document prov:value / ^prov:hadPrimarySource? ?file . `
+  if (areDecisionsReleased) {
+    queryString += `
+      OPTIONAL {
+        ?agendaitem ^dct:subject/besluitvorming:heeftBeslissing/besluitvorming:resultaat ?decisionResultCode .
+      }
+      FILTER (?decisionResultCode NOT IN (${DECISION_RESULT_CODES_LIST
+      .map((uri) => sparqlEscapeUri(uri))
+      .join(", ")}))
+    `
+  }
   if (currentUser.hasLimitedRole) {
     queryString += `
       ?document besluitvorming:vertrouwelijkheidsniveau ?confidentialityLevel .`
@@ -43,7 +54,7 @@ const fetchFilesFromAgenda = async (agendaId, currentUser, extensions) => {
   return parseSparqlResults(data);
 };
 
-const fetchFilesFromAgendaByMandatees = async (agendaId, mandateeIds, currentUser, extensions) => {
+const fetchFilesFromAgendaByMandatees = async (agendaId, mandateeIds, currentUser, extensions, areDecisionsReleased) => {
   let queryString = `
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
@@ -81,6 +92,16 @@ const fetchFilesFromAgendaByMandatees = async (agendaId, mandateeIds, currentUse
       ?document a dossier:Stuk ;
           dct:title ?documentName .
       ?document prov:value / ^prov:hadPrimarySource? ?file . `
+  if (areDecisionsReleased) {
+    queryString += `
+      OPTIONAL {
+        ?agendaitem ^dct:subject/besluitvorming:heeftBeslissing/besluitvorming:resultaat ?decisionResultCode .
+      }
+      FILTER (?decisionResultCode NOT IN (${DECISION_RESULT_CODES_LIST
+      .map((uri) => sparqlEscapeUri(uri))
+      .join(", ")}))
+    `
+  }
   if (currentUser.hasLimitedRole) {
     queryString += `
       ?document besluitvorming:vertrouwelijkheidsniveau ?confidentialityLevel .`
@@ -218,10 +239,32 @@ const fetchDecisionsFromAgenda = async (agendaId, currentUser, extensions) => {
   const data = await query(queryString);
   return parseSparqlResults(data);
 }
+const fetchAreDecisionsReleased = async (agendaId) => {
+  const queryString = `
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+  PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+  PREFIX prov: <http://www.w3.org/ns/prov#>
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+  ASK WHERE {
+    ?agenda a besluitvorming:Agenda ;
+            mu:uuid ${sparqlEscapeString(agendaId)} .
+    ?meeting a besluit:Vergaderactiviteit .
+    ?agenda besluitvorming:isAgendaVoor ?meeting .
+    ?decisionPublicationActivity
+      ext:internalDecisionPublicationActivityUsed ?meeting ;
+      prov:startedAtTime ?decisionPublicationActivityStartDate .
+  }
+  `
+  const response = await query(queryString);
+  return response.boolean;
+}
 
 export {
   fetchFilesFromAgenda,
   fetchFilesFromAgendaByMandatees,
   fetchDecisionsByMandatees,
   fetchDecisionsFromAgenda,
+  fetchAreDecisionsReleased,
 };


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4990

If decisions are released > don't download retracted or postponed agendaitem documents

There will be a period when people can download those documents before the release of decisions.
But not everyone will "know" the decision at that stage, so it makes sense to give all of them.
Still depends on what is available in the graph and the existing filters