### PR TITLE
KAS-5054 add extra routes, make code generic where possible, better error handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM semtech/mu-javascript-template:1.3.5
-MAINTAINER Aad Versteden <madnificent@gmail.com>
+FROM semtech/mu-javascript-template:1.8.0
+LABEL maintainer="info@redpencil.io"

--- a/app.js
+++ b/app.js
@@ -1,36 +1,105 @@
 import { app, errorHandler } from 'mu';
 
-import { fetchFilesFromAgenda, fetchFilesFromAgendaByMandatees, fetchDecisionsByMandatees, fetchDecisionsFromAgenda, fetchAreDecisionsReleased} from './queries/agenda';
+import {
+  fetchFilesFromAgenda,
+  fetchFilesFromAgendaByMandatees,
+  fetchDecisionsByMandatees,
+  fetchDecisionsFromAgenda,
+  fetchAreDecisionsReleased,
+  fetchFilesFromAgendaitem,
+  fetchFilesFromCases,
+  fetchFilesFromSubcases
+} from './queries/agenda';
 import { createJob, insertAndattachCollectionToJob, updateJobStatus, findJobUsingCollection } from './queries/job';
 import { findCollectionByMembers } from './queries/collection';
 import { fetchCurrentUser, filterByConfidentiality } from './queries/user';
 import { overwriteFilenames } from './lib/overwrite-filename';
-import { JSONAPI_JOB_TYPE } from './config';
+import { JSONAPI_JOB_TYPE, EXTENSION_PDF } from './config';
 
-const EXTENSION_PDF = "pdf";
-
-app.post('/agendas/:agenda_id/agendaitems/documents/files/archive', async (req, res) => {
-  const mandateeIdsString = req.query.mandateeIds;
-  const extensions = req.query.pdfOnly === 'true' ? [EXTENSION_PDF] : [] ;
-  let decisions = req.query.decisions === 'true';
-  let files;
-  const currentUser = await fetchCurrentUser(req.headers['mu-session-id']);
-  const areDecisionsReleased = await fetchAreDecisionsReleased(req.params.agenda_id);
-  if (mandateeIdsString) {
-    const mandateeIds = mandateeIdsString.split(',');
-    if (decisions){
-      files = await fetchDecisionsByMandatees(req.params.agenda_id, mandateeIds, currentUser, extensions)
+app.post('/agendas/:agenda_id/agendaitems/documents/files/archive', async (req, res, next) => {
+  try {
+    const mandateeIdsString = req.query.mandateeIds;
+    const extensions = req.query.pdfOnly === 'true' ? [EXTENSION_PDF] : [] ;
+    let decisions = req.query.decisions === 'true';
+    let files;
+    const currentUser = await fetchCurrentUser(req.headers['mu-session-id']);
+    const areDecisionsReleased = await fetchAreDecisionsReleased(req.params.agenda_id);
+    if (mandateeIdsString) {
+      const mandateeIds = mandateeIdsString.split(',');
+      if (decisions){
+        files = await fetchDecisionsByMandatees(req.params.agenda_id, mandateeIds, currentUser, extensions)
+      } else {
+        files = await fetchFilesFromAgendaByMandatees(req.params.agenda_id, mandateeIds, currentUser, extensions, areDecisionsReleased);
+      }
     } else {
-      files = await fetchFilesFromAgendaByMandatees(req.params.agenda_id, mandateeIds, currentUser, extensions, areDecisionsReleased);
+      if (decisions){
+        files = await fetchDecisionsFromAgenda(req.params.agenda_id, currentUser, extensions);
+      } else {
+        files = await fetchFilesFromAgenda(req.params.agenda_id, currentUser, extensions, areDecisionsReleased);
+      }
     }
-  } else {
-    if (decisions){
-      files = await fetchDecisionsFromAgenda(req.params.agenda_id, currentUser, extensions);
-    } else {
-      files = await fetchFilesFromAgenda(req.params.agenda_id, currentUser, extensions, areDecisionsReleased);
-    }
+    files = await filterByConfidentiality(files, currentUser, decisions);
+    await createBundlingJobAndRespondWithPayload(files, res);
+  } catch (err) {
+    console.trace(err);
+    const error = new Error(err.message || 'Something went wrong during the gathering of the documents.');
+    error.status = 500;
+    return next(error);
   }
-  files = await filterByConfidentiality(files, currentUser, decisions);
+});
+
+app.post('/agendaitems/:agendaitem_id/documents/files/archive', async (req, res, next) => {
+  try {
+    const extensions = req.query.pdfOnly === 'true' ? [EXTENSION_PDF] : [] ;
+    const currentUser = await fetchCurrentUser(req.headers['mu-session-id']);
+    let files = await fetchFilesFromAgendaitem(req.params.agendaitem_id, currentUser, extensions);
+    files = await filterByConfidentiality(files, currentUser);
+    await createBundlingJobAndRespondWithPayload(files, res);
+  } catch (err) {
+    console.trace(err);
+    const error = new Error(err.message || 'Something went wrong during the gathering of the documents.');
+    error.status = 500;
+    return next(error);
+  }
+});
+
+app.post('/cases/:case_id/documents/files/archive', async (req, res, next) => {
+  try {
+    const extensions = req.query.pdfOnly === 'true' ? [EXTENSION_PDF] : [] ;
+    const currentUser = await fetchCurrentUser(req.headers['mu-session-id']);
+    let files = await fetchFilesFromCases(req.params.case_id, currentUser, extensions);
+    files = await filterByConfidentiality(files, currentUser);
+    await createBundlingJobAndRespondWithPayload(files, res);
+  } catch (err) {
+    console.trace(err);
+    const error = new Error(err.message || 'Something went wrong during the gathering of the documents.');
+    error.status = 500;
+    return next(error);
+  }
+});
+
+app.post('/subcases/:subcase_id/documents/files/archive', async (req, res, next) => {
+  try {
+    const extensions = req.query.pdfOnly === 'true' ? [EXTENSION_PDF] : [] ;
+    const currentUser = await fetchCurrentUser(req.headers['mu-session-id']);
+    let files = await fetchFilesFromSubcases(req.params.subcase_id, currentUser, extensions);
+    files = await filterByConfidentiality(files, currentUser);
+    await createBundlingJobAndRespondWithPayload(files, res);
+  } catch (err) {
+    console.trace(err);
+    const error = new Error(err.message || 'Something went wrong during the gathering of the documents.');
+    error.status = 500;
+    return next(error);
+  }
+});
+
+async function documentBundlingJob(job, files) {
+  await overwriteFilenames(files);
+  await insertAndattachCollectionToJob(job, files);
+  await updateJobStatus(job.uri, null); // Unset "RUNNING" status, so the file-bundling-service can pick this up
+}
+
+async function createBundlingJobAndRespondWithPayload(files, res) {
   const collection = await findCollectionByMembers(files.map(f => `uri:${f.uri}|name:${f.name}`));
   let job;
   if (collection) {
@@ -40,11 +109,11 @@ app.post('/agendas/:agenda_id/agendaitems/documents/files/archive', async (req, 
     res.status(200);
   } else if (files && files.length > 0) {
     job = await createJob();
-    documentBundlingJobForAgenda(req.params.agenda_id, job, files); // Fire but don't await
+    documentBundlingJob(job, files); // Fire but don't await
     res.status(201);
   } else {
     res.status(500);
-    res.send('Agenda does not have zippable documents');
+    res.send('No zippable documents found');
     return;
   }
   const payload = {};
@@ -60,12 +129,6 @@ app.post('/agendas/:agenda_id/agendaitems/documents/files/archive', async (req, 
     }
   };
   res.send(payload);
-});
-
-async function documentBundlingJobForAgenda (agendaId, job, files) {
-  await overwriteFilenames(files);
-  await insertAndattachCollectionToJob(job, files);
-  await updateJobStatus(job.uri, null); // Unset "RUNNING" status, so the file-bundling-service can pick this up
 }
 
 app.use(errorHandler);

--- a/config.js
+++ b/config.js
@@ -4,6 +4,8 @@ const JSONAPI_JOB_TYPE = 'file-bundling-jobs';
 const LIMITED_ACCESS_ROLES = ['http://themis.vlaanderen.be/id/gebruikersrol/6bcebe59-0cb5-4c5e-ab40-ca98b65887a4'];
 const ACCESS_LEVEL_CONFIDENTIAL = "http://themis.vlaanderen.be/id/concept/toegangsniveau/9692ba4f-f59b-422b-9402-fcbd30a46d17";
 
+const EXTENSION_PDF = "pdf";
+
 const DECISION_RESULT_CODES_LIST = [
   "http://themis.vlaanderen.be/id/concept/beslissing-resultaatcodes/a29b3ffd-0839-45cb-b8f4-e1760f7aacaa",
   "http://themis.vlaanderen.be/id/concept/beslissing-resultaatcodes/453a36e8-6fbd-45d3-b800-ec96e59f273b"
@@ -15,5 +17,6 @@ module.exports = {
   JSONAPI_JOB_TYPE,
   LIMITED_ACCESS_ROLES,
   ACCESS_LEVEL_CONFIDENTIAL,
-  DECISION_RESULT_CODES_LIST
+  DECISION_RESULT_CODES_LIST,
+  EXTENSION_PDF
 };


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5054

- add 3 new endpoints
- made some of the code generic
- added error handling (service crashes when database throws errors)
- bumped base javascript template
- used `next` to respond in the new endpoints

note: It would be possible to make parts of the queries generic. (some parts always come back)
i.m.o. This would result in hard to decypher query with parts coming being inserted left and right.
So opted for duplication instead.