### PR TITLE
KAS-5059 remove extension from decision queries

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,20 +20,20 @@ app.post('/agendas/:agenda_id/agendaitems/documents/files/archive', async (req, 
   try {
     const mandateeIdsString = req.query.mandateeIds;
     const extensions = req.query.pdfOnly === 'true' ? [EXTENSION_PDF] : [] ;
-    let decisions = req.query.decisions === 'true';
+    const decisions = req.query.decisions === 'true';
     let files;
     const currentUser = await fetchCurrentUser(req.headers['mu-session-id']);
     const areDecisionsReleased = await fetchAreDecisionsReleased(req.params.agenda_id);
     if (mandateeIdsString) {
       const mandateeIds = mandateeIdsString.split(',');
       if (decisions){
-        files = await fetchDecisionsByMandatees(req.params.agenda_id, mandateeIds, currentUser, extensions)
+        files = await fetchDecisionsByMandatees(req.params.agenda_id, mandateeIds, currentUser);
       } else {
         files = await fetchFilesFromAgendaByMandatees(req.params.agenda_id, mandateeIds, currentUser, extensions, areDecisionsReleased);
       }
     } else {
       if (decisions){
-        files = await fetchDecisionsFromAgenda(req.params.agenda_id, currentUser, extensions);
+        files = await fetchDecisionsFromAgenda(req.params.agenda_id, currentUser);
       } else {
         files = await fetchFilesFromAgenda(req.params.agenda_id, currentUser, extensions, areDecisionsReleased);
       }

--- a/queries/agenda.js
+++ b/queries/agenda.js
@@ -125,7 +125,7 @@ const fetchFilesFromAgendaByMandatees = async (agendaId, mandateeIds, currentUse
   return parseSparqlResults(data);
 };
 
-const fetchDecisionsByMandatees = async (agendaId, mandateeIds, currentUser, extensions) => {
+const fetchDecisionsByMandatees = async (agendaId, mandateeIds, currentUser) => {
   let queryString = `
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
@@ -180,10 +180,6 @@ const fetchDecisionsByMandatees = async (agendaId, mandateeIds, currentUser, ext
     queryString += `
       ?document besluitvorming:vertrouwelijkheidsniveau ?confidentialityLevel .`
   }
-  if (extensions.length) {
-    queryString += `
-    VALUES ?extension { ${extensions.map(extension => sparqlEscapeString(extension).toLowerCase()).join(" ")} ${extensions.map(extension => sparqlEscapeString(extension).toUpperCase()).join(" ")} }`
-  }
   queryString += `
       ?file a nfo:FileDataObject ;
           nfo:fileName ?name ;
@@ -193,7 +189,7 @@ const fetchDecisionsByMandatees = async (agendaId, mandateeIds, currentUser, ext
   return parseSparqlResults(data);
 };
 
-const fetchDecisionsFromAgenda = async (agendaId, currentUser, extensions) => {
+const fetchDecisionsFromAgenda = async (agendaId, currentUser) => {
   let queryString = `
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
@@ -232,10 +228,6 @@ const fetchDecisionsFromAgenda = async (agendaId, currentUser, extensions) => {
   if (currentUser.hasLimitedRole) {
     queryString += `
       ?document besluitvorming:vertrouwelijkheidsniveau ?confidentialityLevel .`
-  }
-  if (extensions.length) {
-    queryString += `
-    VALUES ?extension { ${extensions.map(extension => sparqlEscapeString(extension).toLowerCase()).join(" ")} ${extensions.map(extension => sparqlEscapeString(extension).toUpperCase()).join(" ")} }`
   }
   queryString += `
       ?file a nfo:FileDataObject ;


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5059

- remove extensions from relevant queries.
- We can still receive pdfOnly = true from frontend for decisions, but we don't do anything with it.