### PR TITLE
KAS-4443 implement getting flattened piece if it exists to download

### DIFF
--- a/lib/overwrite-filename.js
+++ b/lib/overwrite-filename.js
@@ -1,5 +1,5 @@
 import sanitize from 'sanitize-filename';
-import { renameFileFromDocument } from '../queries/document';
+import { renameFileFromDocument, renameFlattenedPieceFromDocument } from '../queries/document';
 
 async function overwriteFilenames (files) {
   /*
@@ -10,10 +10,19 @@ async function overwriteFilenames (files) {
    * We here thus make sure that also the files carry the right name, as the file-bundling-service will use those.
    */
   for (const file of files) {
-    const current = file.name;
-    const fromDocName = `${file.documentName}.${file.extension}`;
-    const expected = sanitize(fromDocName, { replacement: '_' });
-    if (current !== expected) {
+    const currentFileName = file.name;
+    let fromDocName = `${file.originalDocumentName}.${file.extension}`;
+    let expected = sanitize(fromDocName, { replacement: '_' });
+    // if the file is the flattened one, we check the name and also replace flattened piece title since it is often without VR number
+    if (file.flattenedDocumentName) {
+        const newFlattenedDocName = `${file.originalDocumentName} (ondertekend)`;
+        fromDocName = `${newFlattenedDocName}.${file.extension}`;
+        expected = sanitize(fromDocName, { replacement: '_' });
+        if (file.flattenedDocumentName !== newFlattenedDocName) {
+          await renameFlattenedPieceFromDocument(file.document, file.uri, newFlattenedDocName);
+        }
+    }
+    if (currentFileName !== expected) {
       await renameFileFromDocument(file.document, file.uri, expected);
     }
   }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4443

1. changed all collection queries for non decisions to include flattened files
   - for profile based checks, normally the flattened file won't exist in that graph, so the entire optional block fails and the main piece / main file will be selected to download (and also checked for accessLevel)
   - if the main piece is public, but the flattened piece is "intern regering", profile "overheid" will get the main piece in the archive
2. changed all decision collection queries to work with the new logic (get both the name for orginalDocument and flattenedDocument
3. add a piece of logic to reconstruct the name to set on flattened piece and flattened file (with " (ondertekend)")
4. set the title of flattened piece if its not as expected (original name + (ondertekend) )
5. set the name of flattened file if its not as expected (above + extension)

This should:
1. make sure the downloaded archive only contains VR numbered documents (unless downloaded before approving agenda)
2. flattened pieces are renamed also in frontend (only file rename was not visible)
3. files in archive correctly say '(ondertekend)' for flattened pieces
4. subsequent manual downloads of flattened piece will also have a VR number (which is often not the case)


notes:
- After renaming flattened piece, we still show the old name in frontend until after a refresh (is this an issue?)
- this changed feature shouldn't really affect decisions, the flattened pieces already had the correct names since they are always creating after the VR number is assigned.
- Any other flattened piece that was not downloaded can still have a non-VR number, which we may have to address somewhere else like the `document-naming` service (to prevent having the same file with multiple names depending on how/when you download)
- The queries are becoming more bulky and less easy to read. I think still ok? We could extract part of the logic to a constant and add it in where needed (maybe including comments on what it does)

