### PR TITLE
KAS 4883 job model refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ On successful creation of a job.
     "id": "5f680870-5984-11ea-98be-11315490e00b",
     "attributes": {
       "uri": "http://mu.semte.ch/services/file-bundling-service/file-bundling-jobs/5f680870-5984-11ea-98be-11315490e00b",
-      "status": "http://vocab.deri.ie/cogs#Running",
+      "status": "http://redpencil.data.gift/id/concept/JobStatus/busy",
       "created": "2020-02-27T17:12:45.943Z"
     }
   }

--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ On successful creation of a job.
     "attributes": {
       "uri": "http://mu.semte.ch/services/file-bundling-service/file-bundling-jobs/5f680870-5984-11ea-98be-11315490e00b",
       "status": "http://redpencil.data.gift/id/concept/JobStatus/busy",
-      "created": "2020-02-27T17:12:45.943Z"
+      "created": "2020-02-27T17:12:45.943Z",
+      "time-started": "2020-02-27T17:13:45.943Z",
+      "time-ended": "2020-02-27T17:15:45.943Z",
+      "message": "The error message we got if the job failed"
     }
   }
 }

--- a/app.js
+++ b/app.js
@@ -14,7 +14,7 @@ import { createJob, insertAndattachCollectionToJob, updateJobStatus, findJobUsin
 import { findCollectionByMembers } from './queries/collection';
 import { fetchCurrentUser, filterByConfidentiality } from './queries/user';
 import { overwriteFilenames } from './lib/overwrite-filename';
-import { JSONAPI_JOB_TYPE, EXTENSION_PDF } from './config';
+import { JOB, EXTENSION_PDF } from './config';
 
 app.post('/agendas/:agenda_id/agendaitems/documents/files/archive', async (req, res, next) => {
   try {
@@ -94,9 +94,15 @@ app.post('/subcases/:subcase_id/documents/files/archive', async (req, res, next)
 });
 
 async function documentBundlingJob(job, files) {
-  await overwriteFilenames(files);
-  await insertAndattachCollectionToJob(job, files);
-  await updateJobStatus(job.uri, null); // Unset "RUNNING" status, so the file-bundling-service can pick this up
+  try {
+    await overwriteFilenames(files);
+    await insertAndattachCollectionToJob(job, files);
+    await updateJobStatus(job.uri, JOB.STATUSES.SCHEDULED);
+  } catch (e) {
+    console.log(`Failed to initiate the file-bundling-job. reason, ${e.message}`);
+    console.trace(e);
+    await updateJobStatus(job.uri, JOB.STATUSES.FAILED, e.message);
+  }
 }
 
 async function createBundlingJobAndRespondWithPayload(files, res) {
@@ -106,7 +112,15 @@ async function createBundlingJobAndRespondWithPayload(files, res) {
     job = await findJobUsingCollection(collection.uri);
   }
   if (job) {
-    res.status(200);
+    if (job.status === JOB.STATUSES.FAILED && files?.length > 0) {
+      // to prevent a failed job from never retrying again with the same collection
+      await updateJobStatus(job.uri, JOB.STATUSES.BUSY);
+      job = await findJobUsingCollection(collection.uri); // changed metadata after update
+      documentBundlingJob(job, files); // Fire but don't await
+      res.status(201);
+    } else {
+      res.status(200);
+    }
   } else if (files && files.length > 0) {
     job = await createJob();
     documentBundlingJob(job, files); // Fire but don't await
@@ -118,14 +132,15 @@ async function createBundlingJobAndRespondWithPayload(files, res) {
   }
   const payload = {};
   payload.data = {
-    type: JSONAPI_JOB_TYPE,
+    type: JOB.JSONAPI_JOB_TYPE,
     id: job.id,
     attributes: {
       uri: job.uri,
       status: job.status,
       created: job.created,
-      started: job.started,
-      ended: job.ended
+      "time-started": job.started,
+      "time-ended": job.ended,
+      message: job.message
     }
   };
   res.send(payload);

--- a/config.js
+++ b/config.js
@@ -1,10 +1,19 @@
 const RESOURCE_BASE = 'http://mu.semte.ch/services/file-bundling-service';
-const RDF_JOB_TYPE = 'http://mu.semte.ch/vocabularies/ext/FileBundlingJob';
-const JSONAPI_JOB_TYPE = 'file-bundling-jobs';
 const LIMITED_ACCESS_ROLES = ['http://themis.vlaanderen.be/id/gebruikersrol/6bcebe59-0cb5-4c5e-ab40-ca98b65887a4'];
 const ACCESS_LEVEL_CONFIDENTIAL = "http://themis.vlaanderen.be/id/concept/toegangsniveau/9692ba4f-f59b-422b-9402-fcbd30a46d17";
 
 const EXTENSION_PDF = "pdf";
+
+const JOB = {
+  STATUSES: {
+    SCHEDULED: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled',
+    BUSY: 'http://redpencil.data.gift/id/concept/JobStatus/busy',
+    SUCCESS: 'http://redpencil.data.gift/id/concept/JobStatus/success',
+    FAILED: 'http://redpencil.data.gift/id/concept/JobStatus/failed',
+  },
+  RDF_TYPE: 'http://mu.semte.ch/vocabularies/ext/FileBundlingJob',
+  JSONAPI_JOB_TYPE: 'file-bundling-jobs',
+};
 
 const DECISION_RESULT_CODES_LIST = [
   "http://themis.vlaanderen.be/id/concept/beslissing-resultaatcodes/a29b3ffd-0839-45cb-b8f4-e1760f7aacaa",
@@ -19,10 +28,9 @@ const DEBUG_LOG_ACCESS_ROLES = isTruthy(process.env.DEBUG_LOG_ACCESS_ROLES);
 
 module.exports = {
   RESOURCE_BASE,
-  RDF_JOB_TYPE,
-  JSONAPI_JOB_TYPE,
   LIMITED_ACCESS_ROLES,
   ACCESS_LEVEL_CONFIDENTIAL,
+  JOB,
   DECISION_RESULT_CODES_LIST,
   EXTENSION_PDF,
   DEBUG_LOG_ACCESS_ROLES

--- a/queries/job.js
+++ b/queries/job.js
@@ -66,6 +66,7 @@ async function updateJobStatus (uri, status, errorMessage) {
   } else {
     timePred = 'http://www.w3.org/ns/prov#startedAtTime';
   }
+  // no prov:startedAtTime on setting scheduled status
   let queryString = `
 PREFIX cogs: <http://vocab.deri.ie/cogs#>
 PREFIX adms: <http://www.w3.org/ns/adms#>
@@ -77,9 +78,7 @@ DELETE {
             ${sparqlEscapeUri(timePred)} ?time ;
             schema:error ?message .
     }
-}`;
-// no prov:startedAtTime on setting scheduled status
-    queryString += `
+}
 INSERT {
     GRAPH ?g {
         ${sparqlEscapeUri(uri)} adms:status ${sparqlEscapeUri(status)} .

--- a/queries/job.js
+++ b/queries/job.js
@@ -1,31 +1,31 @@
 import { query, update, uuid as generateUuid, sparqlEscapeString, sparqlEscapeUri, sparqlEscapeDateTime } from 'mu';
 import { updateSudo } from '@lblod/mu-auth-sudo';
-import { RESOURCE_BASE, RDF_JOB_TYPE } from '../config';
+import { RESOURCE_BASE, JOB } from '../config';
 import { createCollection } from '../lib/collection';
 import { parseSparqlResults } from './util';
 
-// const SCHEDULED = 'scheduled';
-const RUNNING = 'http://vocab.deri.ie/cogs#Running';
-const SUCCESS = 'http://vocab.deri.ie/cogs#Success';
-const FAIL = 'http://vocab.deri.ie/cogs#Fail';
-
 async function createJob () {
   const uuid = generateUuid();
+  // this is a bit of a hack
+  // we create a job with BUSY status and return the job id to frontend first
+  // after that we create a collection and rename files if needed.
+  // then we set the status to "SCHEDULED" so the file-bundling-service can start bundling the files
+  // the status update on the job is received via deltas
   const job = {
-    uri: RESOURCE_BASE + `/file-bundling-jobs/${uuid}`,
+    uri: RESOURCE_BASE + `/${JOB.JSONAPI_JOB_TYPE}/${uuid}`,
     id: uuid,
-    status: RUNNING,
+    status: JOB.STATUSES.BUSY,
     created: new Date()
   };
   const queryString = `
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   PREFIX dct: <http://purl.org/dc/terms/>
   PREFIX cogs: <http://vocab.deri.ie/cogs#>
+  PREFIX adms: <http://www.w3.org/ns/adms#>
 
   INSERT DATA {
-      ${sparqlEscapeUri(job.uri)} a cogs:Job , ${sparqlEscapeUri(RDF_JOB_TYPE)} ;
-          ext:status ${sparqlEscapeUri(job.status)} ;
+      ${sparqlEscapeUri(job.uri)} a cogs:Job , ${sparqlEscapeUri(JOB.RDF_TYPE)} ;
+          adms:status ${sparqlEscapeUri(job.status)} ;
           mu:uuid ${sparqlEscapeString(job.id)} ;
           dct:created ${sparqlEscapeDateTime(job.created)} .
   }`;
@@ -51,51 +51,56 @@ async function insertAndattachCollectionToJob (job, collectionMembers) {
   }
   WHERE {
       GRAPH ?g {
-          ${sparqlEscapeUri(job.uri)} a ${sparqlEscapeUri(RDF_JOB_TYPE)} .
+          ${sparqlEscapeUri(job.uri)} a ${sparqlEscapeUri(JOB.RDF_TYPE)} .
       }
   }`;
   await updateSudo(queryString);
   return job;
 }
 
-async function updateJobStatus (uri, status) {
+async function updateJobStatus (uri, status, errorMessage) {
   const time = new Date();
   let timePred;
-  if (status === SUCCESS || status === FAIL) { // final statusses
+  if (status === JOB.STATUSES.SUCCESS || status === JOB.STATUSES.FAILED) { // final statuses
     timePred = 'http://www.w3.org/ns/prov#endedAtTime';
   } else {
     timePred = 'http://www.w3.org/ns/prov#startedAtTime';
   }
-  const escapedUri = sparqlEscapeUri(uri);
   let queryString = `
-PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 PREFIX cogs: <http://vocab.deri.ie/cogs#>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX schema: <http://schema.org/>
 
 DELETE {
     GRAPH ?g {
-      ${escapedUri} ext:status ?status .`;
-  if (status) {
-    queryString += `
-      ${escapedUri} ${sparqlEscapeUri(timePred)} ?time .`;
-  }
-  queryString += `
+        ${sparqlEscapeUri(uri)} adms:status ?status ;
+            ${sparqlEscapeUri(timePred)} ?time ;
+            schema:error ?message .
     }
 }`;
-  if (status) {
+// no prov:startedAtTime on setting scheduled status
     queryString += `
 INSERT {
     GRAPH ?g {
-        ${escapedUri} ext:status ${sparqlEscapeUri(status)} ;
-            ${sparqlEscapeUri(timePred)} ${sparqlEscapeDateTime(time)} .
+        ${sparqlEscapeUri(uri)} adms:status ${sparqlEscapeUri(status)} .
+        ${
+          status !== JOB.STATUSES.SCHEDULED
+            ? `${sparqlEscapeUri(uri)} ${sparqlEscapeUri(timePred)} ${sparqlEscapeDateTime(time)} .`
+            : ""
+        }
+        ${
+          errorMessage
+            ? `${sparqlEscapeUri(uri)} schema:error ${sparqlEscapeString(errorMessage)} .`
+            : ""
+        }
     }
-}`;
-  }
-  queryString += `
+}
 WHERE {
     GRAPH ?g {
-        ${escapedUri} a ${sparqlEscapeUri(RDF_JOB_TYPE)} .
-        OPTIONAL { ${escapedUri} ext:status ?status }
-        OPTIONAL { ${escapedUri} ${sparqlEscapeUri(timePred)} ?time }
+        ${sparqlEscapeUri(uri)} a ${sparqlEscapeUri(JOB.RDF_TYPE)} .
+        OPTIONAL { ${sparqlEscapeUri(uri)} adms:status ?status }
+        OPTIONAL { ${sparqlEscapeUri(uri)} ${sparqlEscapeUri(timePred)} ?time }
+        OPTIONAL { ${sparqlEscapeUri(uri)} schema:error ?message }
     }
 }`;
   await updateSudo(queryString);
@@ -105,19 +110,21 @@ async function findJobUsingCollection (collection) {
   const queryString = `
   PREFIX prov: <http://www.w3.org/ns/prov#>
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   PREFIX dct: <http://purl.org/dc/terms/>
+  PREFIX adms: <http://www.w3.org/ns/adms#>
+  PREFIX schema: <http://schema.org/>
 
-  SELECT (?job AS ?uri) (?uuid as ?id) ?generated ?status ?created ?started ?ended WHERE {
+  SELECT (?job AS ?uri) (?uuid as ?id) ?generated ?status ?created ?started ?ended ?message WHERE {
       ${sparqlEscapeUri(collection)} a prov:Collection .
-      ?job a ${sparqlEscapeUri(RDF_JOB_TYPE)} ;
+      ?job a ${sparqlEscapeUri(JOB.RDF_TYPE)} ;
           mu:uuid ?uuid ;
           prov:used ${sparqlEscapeUri(collection)} .
-      OPTIONAL { ?job ext:status ?status }
+      OPTIONAL { ?job adms:status ?status }
       OPTIONAL { ?job prov:generated ?generated }
       OPTIONAL { ?job dct:created ?created }
       OPTIONAL { ?job prov:startedAtTime ?started }
       OPTIONAL { ?job prov:endedAtTime ?ended }
+      OPTIONAL { ?job schema:error ?message }
   }`;
   const results = await query(queryString); // NO SUDO!
   const parsedResults = parseSparqlResults(results);
@@ -132,6 +139,5 @@ export {
   createJob,
   insertAndattachCollectionToJob,
   updateJobStatus,
-  RUNNING, SUCCESS, FAIL,
   findJobUsingCollection
 };


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4883

ext:status > adms:status
prov:startedAtTime and prov:endedAtTime
use redpencil statuses instead of cogs (cogs doesn't have "scheduled" status which is needed for some jobs)
move stuff to config
update readme


side tracking:
more error handling on collection creation
Jobs that fail are rescheduled here (before refactor, we didn't set status on failure here, so we kept retrying because of no status)
correct api response to match the model in resources