### PR TITLE
KAS-1989 add option to download only new documents from agenda

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,7 +22,7 @@ app.post('/agendas/:agenda_id/agendaitems/documents/files/archive', async (req, 
     const mandateeIdsString = req.query.mandateeIds;
     const extensions = req.query.pdfOnly === 'true' ? [EXTENSION_PDF] : [] ;
     const decisions = req.query.decisions === 'true';
-    const currentAgendaOnly = req.query.currentAgendaOnly === 'true';
+    const newDocumentsOnly = req.query.newDocumentsOnly === 'true';
     let files;
     const currentUser = await fetchCurrentUser(req.headers['mu-session-id']);
     const areDecisionsReleased = await fetchAreDecisionsReleased(req.params.agenda_id);
@@ -31,13 +31,13 @@ app.post('/agendas/:agenda_id/agendaitems/documents/files/archive', async (req, 
       if (decisions){
         files = await fetchDecisionsByMandatees(req.params.agenda_id, mandateeIds, currentUser);
       } else {
-        files = await fetchFilesFromAgendaByMandatees(req.params.agenda_id, mandateeIds, currentUser, extensions, areDecisionsReleased, currentAgendaOnly);
+        files = await fetchFilesFromAgendaByMandatees(req.params.agenda_id, mandateeIds, currentUser, extensions, areDecisionsReleased, newDocumentsOnly);
       }
     } else {
       if (decisions){
         files = await fetchDecisionsFromAgenda(req.params.agenda_id, currentUser);
       } else {
-        files = await fetchFilesFromAgenda(req.params.agenda_id, currentUser, extensions, areDecisionsReleased, currentAgendaOnly);
+        files = await fetchFilesFromAgenda(req.params.agenda_id, currentUser, extensions, areDecisionsReleased, newDocumentsOnly);
       }
     }
     files = await filterByConfidentiality(files, currentUser, decisions);

--- a/app.js
+++ b/app.js
@@ -22,6 +22,7 @@ app.post('/agendas/:agenda_id/agendaitems/documents/files/archive', async (req, 
     const mandateeIdsString = req.query.mandateeIds;
     const extensions = req.query.pdfOnly === 'true' ? [EXTENSION_PDF] : [] ;
     const decisions = req.query.decisions === 'true';
+    const currentAgendaOnly = req.query.currentAgendaOnly === 'true';
     let files;
     const currentUser = await fetchCurrentUser(req.headers['mu-session-id']);
     const areDecisionsReleased = await fetchAreDecisionsReleased(req.params.agenda_id);
@@ -30,13 +31,13 @@ app.post('/agendas/:agenda_id/agendaitems/documents/files/archive', async (req, 
       if (decisions){
         files = await fetchDecisionsByMandatees(req.params.agenda_id, mandateeIds, currentUser);
       } else {
-        files = await fetchFilesFromAgendaByMandatees(req.params.agenda_id, mandateeIds, currentUser, extensions, areDecisionsReleased);
+        files = await fetchFilesFromAgendaByMandatees(req.params.agenda_id, mandateeIds, currentUser, extensions, areDecisionsReleased, currentAgendaOnly);
       }
     } else {
       if (decisions){
         files = await fetchDecisionsFromAgenda(req.params.agenda_id, currentUser);
       } else {
-        files = await fetchFilesFromAgenda(req.params.agenda_id, currentUser, extensions, areDecisionsReleased);
+        files = await fetchFilesFromAgenda(req.params.agenda_id, currentUser, extensions, areDecisionsReleased, currentAgendaOnly);
       }
     }
     files = await filterByConfidentiality(files, currentUser, decisions);

--- a/queries/agenda.js
+++ b/queries/agenda.js
@@ -2,7 +2,7 @@ import { sparqlEscapeString, sparqlEscapeUri, query } from 'mu';
 import { parseSparqlResults } from './util';
 import { DECISION_RESULT_CODES_LIST } from '../config';
 
-const fetchFilesFromAgenda = async (agendaId, currentUser, extensions, areDecisionsReleased) => {
+const fetchFilesFromAgenda = async (agendaId, currentUser, extensions, areDecisionsReleased, currentAgendaOnly) => {
   let queryString = `
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
@@ -29,7 +29,14 @@ const fetchFilesFromAgenda = async (agendaId, currentUser, extensions, areDecisi
       ?originalDocument a dossier:Stuk ;
           dct:title ?originalDocumentName .
       OPTIONAL { ?nextDocument pav:previousVersion ?originalDocument . }
-      FILTER NOT EXISTS { ?agendaitem besluitvorming:geagendeerdStuk ?nextDocument . }
+      FILTER NOT EXISTS { ?agendaitem besluitvorming:geagendeerdStuk ?nextDocument . } `
+  if (currentAgendaOnly) {
+    queryString += `
+      OPTIONAL { ?agendaitem prov:wasRevisionOf ?previousAgendaitem . }
+      FILTER NOT EXISTS { ?previousAgendaitem besluitvorming:geagendeerdStuk ?originalDocument . }
+    `
+  }
+    queryString += `
       {
           ?originalDocument prov:value ?originalFile .
       } UNION {
@@ -70,7 +77,7 @@ const fetchFilesFromAgenda = async (agendaId, currentUser, extensions, areDecisi
   return parseSparqlResults(data);
 };
 
-const fetchFilesFromAgendaByMandatees = async (agendaId, mandateeIds, currentUser, extensions, areDecisionsReleased) => {
+const fetchFilesFromAgendaByMandatees = async (agendaId, mandateeIds, currentUser, extensions, areDecisionsReleased, currentAgendaOnly) => {
   let queryString = `
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
@@ -93,7 +100,14 @@ const fetchFilesFromAgendaByMandatees = async (agendaId, mandateeIds, currentUse
       ?agendaitem a besluit:Agendapunt ;
           besluitvorming:geagendeerdStuk ?originalDocument .
       OPTIONAL { ?nextDocument pav:previousVersion ?originalDocument . }
-      FILTER NOT EXISTS { ?agendaitem besluitvorming:geagendeerdStuk ?nextDocument . }
+      FILTER NOT EXISTS { ?agendaitem besluitvorming:geagendeerdStuk ?nextDocument . }`
+  if (currentAgendaOnly) {
+    queryString += `
+      OPTIONAL { ?agendaitem prov:wasRevisionOf ?previousAgendaitem . }
+      FILTER NOT EXISTS { ?previousAgendaitem besluitvorming:geagendeerdStuk ?originalDocument . }
+    `
+  }
+  queryString += `
       {
         ?agenda a besluitvorming:Agenda ;
           mu:uuid ${sparqlEscapeString(agendaId)} ;

--- a/queries/agenda.js
+++ b/queries/agenda.js
@@ -2,7 +2,7 @@ import { sparqlEscapeString, sparqlEscapeUri, query } from 'mu';
 import { parseSparqlResults } from './util';
 import { DECISION_RESULT_CODES_LIST } from '../config';
 
-const fetchFilesFromAgenda = async (agendaId, currentUser, extensions, areDecisionsReleased, currentAgendaOnly) => {
+const fetchFilesFromAgenda = async (agendaId, currentUser, extensions, areDecisionsReleased, newDocumentsOnly) => {
   let queryString = `
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
@@ -30,7 +30,7 @@ const fetchFilesFromAgenda = async (agendaId, currentUser, extensions, areDecisi
           dct:title ?originalDocumentName .
       OPTIONAL { ?nextDocument pav:previousVersion ?originalDocument . }
       FILTER NOT EXISTS { ?agendaitem besluitvorming:geagendeerdStuk ?nextDocument . } `
-  if (currentAgendaOnly) {
+  if (newDocumentsOnly) {
     queryString += `
       OPTIONAL { ?agendaitem prov:wasRevisionOf ?previousAgendaitem . }
       FILTER NOT EXISTS { ?previousAgendaitem besluitvorming:geagendeerdStuk ?originalDocument . }
@@ -77,7 +77,7 @@ const fetchFilesFromAgenda = async (agendaId, currentUser, extensions, areDecisi
   return parseSparqlResults(data);
 };
 
-const fetchFilesFromAgendaByMandatees = async (agendaId, mandateeIds, currentUser, extensions, areDecisionsReleased, currentAgendaOnly) => {
+const fetchFilesFromAgendaByMandatees = async (agendaId, mandateeIds, currentUser, extensions, areDecisionsReleased, newDocumentsOnly) => {
   let queryString = `
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
@@ -101,7 +101,7 @@ const fetchFilesFromAgendaByMandatees = async (agendaId, mandateeIds, currentUse
           besluitvorming:geagendeerdStuk ?originalDocument .
       OPTIONAL { ?nextDocument pav:previousVersion ?originalDocument . }
       FILTER NOT EXISTS { ?agendaitem besluitvorming:geagendeerdStuk ?nextDocument . }`
-  if (currentAgendaOnly) {
+  if (newDocumentsOnly) {
     queryString += `
       OPTIONAL { ?agendaitem prov:wasRevisionOf ?previousAgendaitem . }
       FILTER NOT EXISTS { ?previousAgendaitem besluitvorming:geagendeerdStuk ?originalDocument . }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-1989

- add option to download only "new" documents which bottles down to checking if there is a previous agendaitem and ignoring all documents that exist on it.