### PR TITLE
Update readme to deprecate service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kaleidos file bundling job creation service
 
+> **⚠️ DEPRECATED:** This service has been merged into the [file-bundling-service](https://github.com/kanselarij-vlaanderen/file-bundling-service) (as of file-bundling-service v4.0.0). All endpoints below are now served by that service directly. This repository is no longer maintained.
+
 Service to create [file-bundling jobs](https://github.com/kanselarij-vlaanderen/file-bundling-service) for a set of files relating to a Kaleidos-specific entity.
 
 ## Rationale


### PR DESCRIPTION
After integrating the file bundling job creation service into the file creation service, we can deprecate this service.
Updated the readme to reflect that.